### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@
 name: 'Label stale issues and PR'
 on:
   schedule:
-    - cron: '0 17 * * *'
+    - cron: '30 17 * * *'
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+# From https://github.com/marketplace/actions/close-stale-issues
+name: 'Label stale issues and PR'
+on:
+  schedule:
+    - cron: '0 17 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.0.0
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 1 day with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 1 day with no activity.'
+          days-before-stale: 1
+          days-before-close: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
From https://github.com/marketplace/actions/close-stale-issues

Configured the workflow to ensure PRs and issues are only labelled as stale, not closed, after 1 day of inactivity (given that the project is due in two days)